### PR TITLE
Refactor coin counter and fix 'Coin: ' not showing

### DIFF
--- a/Assets/Scenes/Prototype1.unity
+++ b/Assets/Scenes/Prototype1.unity
@@ -3538,7 +3538,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   coinCounter: {fileID: 656170259}
-  player: {fileID: 964841833}
 --- !u!114 &1543283766
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/CoinCounter.cs
+++ b/Assets/Scripts/CoinCounter.cs
@@ -2,15 +2,18 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
-using UnityEngine;
 using TMPro;
+using UnityEngine;
+
 
 public class CoinCounter : MonoBehaviour
 {
-	public TMP_Text coinCounter;
-	public GameObject player;
-	private void Update()
+	public TextMeshProUGUI coinCounter;
+	private const string LabelBase = "Coins: ";
+	
+
+	public void UpdateCount(int value)
 	{
-		coinCounter.text = player.GetComponent<PlayerInventory>().currentCoins.ToString();
+		coinCounter.text = LabelBase + value;
 	}
 }

--- a/Assets/Scripts/PlayerInventory.cs
+++ b/Assets/Scripts/PlayerInventory.cs
@@ -6,18 +6,21 @@ using UnityEngine;
 
 public class PlayerInventory : MonoBehaviour
 {
-    public int currentCoins;
+    [SerializeField] private int currentCoins;
+    private CoinCounter coinCounter;
 
-    private void Start()
-    {
-        currentCoins = 0;
+    private void Start() {
+        coinCounter = GameObject.FindWithTag("MainCanvas").GetComponent<CoinCounter>();
+        currentCoins = 0; // Get this from a persistant source in the future
+        coinCounter.UpdateCount(currentCoins);
     }
 
     private void OnTriggerEnter(Collider other)
     {
-        if (other.tag == "Coin")
+        if (other.CompareTag("Coin"))
         {
             currentCoins += 1;
+            coinCounter.UpdateCount(currentCoins);
             Destroy(other.gameObject);
         }
     }


### PR DESCRIPTION
In order to avoid doing an `Update()` call on the main canvas every frame, only update the coin counter when the player actually picks up a coin